### PR TITLE
Add global 401 error interceptor

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-import Axios, { AxiosInstance, CancelTokenStatic } from 'axios'
+import Axios, { AxiosInstance, CancelTokenStatic, AxiosResponse, AxiosError } from 'axios'
 import { getRequestToken, onRequestTokenUpdate } from '@nextcloud/auth'
 
 interface CancelableAxiosInstance extends AxiosInstance {
@@ -14,6 +14,19 @@ const client: any = Axios.create({
 const cancelableClient: CancelableAxiosInstance = Object.assign(client, {
 	CancelToken: Axios.CancelToken,
 	isCancel: Axios.isCancel,
+})
+
+// Add a 401 response interceptor
+cancelableClient.interceptors.response.use((response: AxiosResponse): AxiosResponse     => {
+	if (response.status === 401) {
+		location.reload()
+	}
+	return response
+}, (error: AxiosError): Promise<AxiosError> => {
+	if (error.response?.status === 401) {
+		location.reload()
+	}
+	return Promise.reject(error)
 })
 
 onRequestTokenUpdate(token => client.defaults.headers.requesttoken = token)


### PR DESCRIPTION
The interceptor will reload the page, the server should then trigger a
redirection to the login page with the correct redirect_uri param set.

See discussion in https://github.com/nextcloud/viewer/pull/1086

Signed-off-by: Carl Schwan <carl@carlschwan.eu>