### PR TITLE
Add optional maintenance mode retry handler for short downtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,25 @@ const baseURL = generateUrl('/apps/your_app_id/api')
 axios.defaults.baseURL = baseURL
 ```
 
+## Retry handling
+
+This package can optionally retry requests if they fail due to Nextcloud's *maintenance mode*. To activate this feature, pass
+`retryIfMaintenanceMode: true` into the request options. This mechanism will only catch relatively short server maintenance
+downtime in the range of seconds to a minute. Any longer downtime still has to be handled by the application, show feedback
+to the user, reload the page etc.
+
+```js
+import axios from '@nextcloud/axios'
+
+const pizzas = await axios.get('/apps/pizza/api/pizzas', {
+    retryIfMaintenanceMode: true,
+})
+const myPizza = await axios.post('/apps/pizza/api/pizzas', { toppings: ['pineapple'] }, {
+    retryIfMaintenanceMode: true,
+})
+```
+
+
 References
 
 - [@nextcloud/router](https://github.com/nextcloud/nextcloud-router)

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,8 @@
 import Axios, { AxiosInstance, CancelTokenStatic } from 'axios'
 import { getRequestToken, onRequestTokenUpdate } from '@nextcloud/auth'
 
+import { onError } from './interceptors/maintenance-mode'
+
 interface CancelableAxiosInstance extends AxiosInstance {
 	CancelToken: CancelTokenStatic
 	isCancel(value: any): boolean
@@ -15,6 +17,8 @@ const cancelableClient: CancelableAxiosInstance = Object.assign(client, {
 	CancelToken: Axios.CancelToken,
 	isCancel: Axios.isCancel,
 })
+
+cancelableClient.interceptors.response.use(r => r, onError(cancelableClient))
 
 onRequestTokenUpdate(token => client.defaults.headers.requesttoken = token)
 

--- a/test/interceptors/maintenance-mode.test.js
+++ b/test/interceptors/maintenance-mode.test.js
@@ -1,0 +1,97 @@
+import { onError } from '../../lib/interceptors/maintenance-mode'
+
+describe('maintenance mode interceptor', () => {
+
+    let axiosMock
+    let interceptor
+
+    beforeEach(() => {
+        axiosMock = jest.fn()
+        interceptor = onError(axiosMock)
+    })
+
+    it('does not retry HTTP404', async () => {
+        try {
+            await interceptor({
+                config: {},
+                response: {
+                    status: 404,
+                    headers: {},
+                },
+                request: {
+                    responseURL: '/some/url',
+                },
+            })
+        } catch (e) {
+            expect(e.response.status).toBe(404)
+            expect(axiosMock).not.toHaveBeenCalled()
+            return
+        }
+        fail('Should not be reached')
+    })
+
+    it('does not retry if not asked to', async () => {
+        try {
+            await interceptor({
+                config: {},
+                response: {
+                    status: 503,
+                    headers: {
+                        'x-nextcloud-maintenance-mode': '1',
+                    },
+                },
+                request: {
+                    responseURL: '/some/url',
+                },
+            })
+        } catch (e) {
+            expect(e.response.status).toBe(503)
+            expect(axiosMock).not.toHaveBeenCalled()
+            return
+        }
+        fail('Should not be reached')
+    })
+
+    it('does not retry if header missing', async () => {
+        try {
+            await interceptor({
+                config: {
+                    retryIfMaintenanceMode: true,
+                },
+                response: {
+                    status: 503,
+                    headers: {},
+                },
+                request: {
+                    responseURL: '/some/url',
+                },
+            })
+        } catch (e) {
+            expect(e.response.status).toBe(503)
+            expect(axiosMock).not.toHaveBeenCalled()
+            return
+        }
+        fail('Should not be reached')
+    })
+
+    it('does retry', async () => {
+        axiosMock.mockReturnValue(42)
+        const response = await interceptor({
+            config: {
+                retryIfMaintenanceMode: true,
+            },
+            response: {
+                status: 503,
+                headers: {
+                    'x-nextcloud-maintenance-mode': '1',
+                },
+            },
+            request: {
+                responseURL: '/some/url',
+            },
+        })
+
+        expect(axiosMock).toHaveBeenCalled()
+        expect(response).toBe(42)
+    })
+})


### PR DESCRIPTION
For https://github.com/nextcloud/mail/issues/5714.

See the readme changes for a description.

This is a bit of an experiment, so I'm making this optional for now. If we find out that this is the way to go by default we can make it default enabled in a major version bump.

Babel-jest added to test the new module.

This only works with https://github.com/nextcloud/server/pull/33173, so Nextcloud 25.