### PR TITLE
Add retry handler for expired CSRF tokens

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,8 @@
 import Axios, { AxiosInstance, CancelTokenStatic } from 'axios'
 import { getRequestToken, onRequestTokenUpdate } from '@nextcloud/auth'
 
-import { onError } from './interceptors/maintenance-mode'
+import { onError as onCsrfTokenError } from './interceptors/csrf-token'
+import { onError as onMaintenanceModeError } from './interceptors/maintenance-mode'
 
 interface CancelableAxiosInstance extends AxiosInstance {
 	CancelToken: CancelTokenStatic
@@ -18,7 +19,8 @@ const cancelableClient: CancelableAxiosInstance = Object.assign(client, {
 	isCancel: Axios.isCancel,
 })
 
-cancelableClient.interceptors.response.use(r => r, onError(cancelableClient))
+cancelableClient.interceptors.response.use(r => r, onCsrfTokenError(cancelableClient))
+cancelableClient.interceptors.response.use(r => r, onMaintenanceModeError(cancelableClient))
 
 onRequestTokenUpdate(token => client.defaults.headers.requesttoken = token)
 

--- a/lib/interceptors/csrf-token.ts
+++ b/lib/interceptors/csrf-token.ts
@@ -1,0 +1,29 @@
+import { generateUrl } from '@nextcloud/router'
+
+const RETRY_KEY = Symbol('csrf-retry')
+
+export const onError = axios => async (error) => {
+	const { config, response, request: { responseURL } } = error
+	const { status } = response
+
+	if (status === 412
+		&& response?.data?.message === 'CSRF check failed'
+		&& config[RETRY_KEY] === undefined) {
+		console.warn(`Request to ${responseURL} failed because of a CSRF mismatch. Fetching a new token`)
+
+		const { data: { token } } = await axios.get(generateUrl('/csrftoken'))
+		console.debug(`New request token ${token} fetched`)
+		axios.defaults.headers.requesttoken = token
+
+		return axios({
+			...config,
+			headers: {
+				...config.headers,
+				requesttoken: token,
+			},
+			[RETRY_KEY]: true,
+		})
+	}
+
+	return Promise.reject(error)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@nextcloud/auth": "^2.0.0",
+				"@nextcloud/router": "^2.0.0",
 				"axios": "^0.27.2",
 				"tslib": "^2.4.0"
 			},
@@ -2186,6 +2187,14 @@
 				"npm": "^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/@nextcloud/router": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.0.0.tgz",
+			"integrity": "sha512-GyHYNYrYAZRBGD5VxRggcbahdJ/zCkXb8+ERVfuaosT+nHMjJSmenTD6Uyct41qGm0p3Az4xRCXGyZGJM0NEUQ==",
+			"dependencies": {
+				"core-js": "^3.6.4"
+			}
+		},
 		"node_modules/@rollup/plugin-typescript": {
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.5.0.tgz",
@@ -3044,6 +3053,16 @@
 			"dev": true,
 			"dependencies": {
 				"safe-buffer": "~5.1.1"
+			}
+		},
+		"node_modules/core-js": {
+			"version": "3.25.3",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.3.tgz",
+			"integrity": "sha512-y1hvKXmPHvm5B7w4ln1S4uc9eV/O5+iFExSRUimnvIph11uaizFR8LFMdONN8hG3P2pipUfX4Y/fR8rAEtcHcQ==",
+			"hasInstallScript": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/core-js"
 			}
 		},
 		"node_modules/core-js-compat": {
@@ -7475,6 +7494,14 @@
 				"semver": "^7.3.7"
 			}
 		},
+		"@nextcloud/router": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.0.0.tgz",
+			"integrity": "sha512-GyHYNYrYAZRBGD5VxRggcbahdJ/zCkXb8+ERVfuaosT+nHMjJSmenTD6Uyct41qGm0p3Az4xRCXGyZGJM0NEUQ==",
+			"requires": {
+				"core-js": "^3.6.4"
+			}
+		},
 		"@rollup/plugin-typescript": {
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.5.0.tgz",
@@ -8163,6 +8190,11 @@
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
+		},
+		"core-js": {
+			"version": "3.25.3",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.3.tgz",
+			"integrity": "sha512-y1hvKXmPHvm5B7w4ln1S4uc9eV/O5+iFExSRUimnvIph11uaizFR8LFMdONN8hG3P2pipUfX4Y/fR8rAEtcHcQ=="
 		},
 		"core-js-compat": {
 			"version": "3.25.3",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
 		"build": "rollup --config rollup.config.js",
 		"check-types": "tsc",
 		"dev": "rollup --config rollup.config.js --watch",
-		"test": "jest",
-		"test:watch": "jest --watchAll"
+		"test": "jest --setupFiles '<rootDir>/test/setup.js'",
+		"test:watch": "jest --setupFiles '<rootDir>/test/setup.js' --watchAll"
 	},
 	"repository": {
 		"type": "git",
@@ -37,6 +37,7 @@
 	"homepage": "https://github.com/nextcloud/nextcloud-axios#readme",
 	"dependencies": {
 		"@nextcloud/auth": "^2.0.0",
+		"@nextcloud/router": "^2.0.0",
 		"axios": "^0.27.2",
 		"tslib": "^2.4.0"
 	},

--- a/test/interceptors/csrf-token.test.js
+++ b/test/interceptors/csrf-token.test.js
@@ -1,0 +1,88 @@
+import { onError } from '../../lib/interceptors/csrf-token'
+
+describe('CSRF token', () => {
+
+    let axiosMock
+    let interceptor
+
+    beforeEach(() => {
+        axiosMock = jest.fn()
+        axiosMock.get = jest.fn()
+        axiosMock.defaults = {
+            headers: {
+                requesttoken: 'old',
+            },
+        },
+        interceptor = onError(axiosMock)
+    })
+
+    it('does not retry successful requests', async () => {
+        try {
+            await interceptor({
+                config: {},
+                response: {
+                    status: 200,
+                    headers: {},
+                },
+                request: {
+                    responseURL: '/some/url',
+                },
+            })
+        } catch (e) {
+            expect(e.response.status).toBe(200)
+            expect(axiosMock).not.toHaveBeenCalled()
+            return
+        }
+        fail('Should not be reached')
+    })
+
+    it('does not retry if header missing', async () => {
+        try {
+            await interceptor({
+                config: {
+                    retryIfMaintenanceMode: true,
+                },
+                response: {
+                    status: 412,
+                    headers: {},
+                },
+                request: {
+                    responseURL: '/some/url',
+                },
+            })
+        } catch (e) {
+            expect(e.response.status).toBe(412)
+            expect(axiosMock).not.toHaveBeenCalled()
+            return
+        }
+        fail('Should not be reached')
+    })
+
+    it('does retry', async () => {
+        axiosMock.mockReturnValue({
+            status: 200,
+        })
+        axiosMock.get.mockReturnValue(Promise.resolve({
+            data: {
+                token: '123',
+            },
+            headers: {},
+        }))
+        const response = await interceptor({
+            config: {},
+            response: {
+                status: 412,
+                data: {
+                    message: 'CSRF check failed',
+                },
+            },
+            request: {
+                responseURL: '/some/url',
+            },
+        })
+        expect(axiosMock).toHaveBeenCalled()
+        expect(axiosMock.get).toHaveBeenCalled()
+        expect(axiosMock.defaults.headers.requesttoken).toBe('123')
+        expect(response?.status).toBe(200)
+    })
+})

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,8 @@
+global.OC = {
+	config: {
+        modRewriteWorking: true,
+    },
+    isUserAdmin() {
+        return false
+    },
+}


### PR DESCRIPTION
For https://github.com/nextcloud/mail/issues/5714

- [x] Requires https://github.com/nextcloud/nextcloud-axios/pull/510

This fetches a new CSRF token right when it doesn't validate anymore.

### How to test

1) Log into Nextcloud
2) Open a second tab
3) Log out on the second tab
4) Log in again on the second tab
5) Trigger an action with a HTTP request on the first tab

On master: request fails with 412, the error bubbles up and the action fails.
Here: request fails with 412, there is another request to fetch a CSRF token, the request is sent again and works. The action succeeds.