### PR TITLE
Add optional page reload handler for expired sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const baseURL = generateUrl('/apps/your_app_id/api')
 axios.defaults.baseURL = baseURL
 ```
 
-## Retry handling
+### Retry handling
 
 This package can optionally retry requests if they fail due to Nextcloud's *maintenance mode*. To activate this feature, pass
 `retryIfMaintenanceMode: true` into the request options. This mechanism will only catch relatively short server maintenance
@@ -56,6 +56,18 @@ const myPizza = await axios.post('/apps/pizza/api/pizzas', { toppings: ['pineapp
 })
 ```
 
+### Expired sessions handling
+
+This package can optionally trigger a page reload whenever a request fails due to an expired user session. This interrupts
+application logic and should be the last resort. If possible, handle the expired session higher up in the application.
+
+```js
+import axios from '@nextcloud/axios'
+
+const response = await axios.get('/apps/foo/api/bar', {
+    reloadExpiredSession: true,
+})
+```
 
 References
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,6 +3,7 @@ import { getRequestToken, onRequestTokenUpdate } from '@nextcloud/auth'
 
 import { onError as onCsrfTokenError } from './interceptors/csrf-token'
 import { onError as onMaintenanceModeError } from './interceptors/maintenance-mode'
+import { onError as onNotLoggedInError } from './interceptors/not-logged-in'
 
 interface CancelableAxiosInstance extends AxiosInstance {
 	CancelToken: CancelTokenStatic
@@ -21,6 +22,7 @@ const cancelableClient: CancelableAxiosInstance = Object.assign(client, {
 
 cancelableClient.interceptors.response.use(r => r, onCsrfTokenError(cancelableClient))
 cancelableClient.interceptors.response.use(r => r, onMaintenanceModeError(cancelableClient))
+cancelableClient.interceptors.response.use(r => r, onNotLoggedInError)
 
 onRequestTokenUpdate(token => client.defaults.headers.requesttoken = token)
 

--- a/lib/interceptors/not-logged-in.ts
+++ b/lib/interceptors/not-logged-in.ts
@@ -1,0 +1,15 @@
+export const onError = async (error) => {
+	const { config, response, request: { responseURL } } = error
+	const { status } = response
+
+	if (status === 401
+		&& response?.data?.message === 'Current user is not logged in'
+		&& config.reloadExpiredSession
+		&& window?.location) {
+		console.error(`Request to ${responseURL} failed because the user session expired. Reloading the page …`)
+
+		window.location.reload()
+	}
+
+	return Promise.reject(error)
+}

--- a/test/interceptors/not-logged-in.test.js
+++ b/test/interceptors/not-logged-in.test.js
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { onError } from '../../lib/interceptors/not-logged-in'
+
+describe('not logged in interceptor', () => {
+    const original = window.location;
+
+    beforeEach(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { reload: jest.fn() },
+        });
+    })
+
+    afterEach(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: original,
+        });
+    })
+
+    it('does not reload arbitrary 401s', async () => {
+        try {
+            await onError({
+                config: {},
+                response: {
+                    status: 401,
+                    headers: {},
+                },
+                request: {
+                    responseURL: '/some/url',
+                },
+            })
+        } catch (e) {
+            expect(e.response.status).toBe(401)
+            expect(window.location.reload).not.toHaveBeenCalled()
+            return
+        }
+        fail('Should not be reached')
+    })
+
+    it('does not reload if not asked to', async () => {
+        try {
+            await onError({
+                config: {},
+                response: {
+                    status: 401,
+                    data: {
+                        message: 'Current user is not logged in',
+                    },
+                    headers: {},
+                },
+                request: {
+                    responseURL: '/some/url',
+                },
+            })
+        } catch (e) {
+            expect(e.response.status).toBe(401)
+            expect(window.location.reload).not.toHaveBeenCalled()
+            return
+        }
+        fail('Should not be reached')
+    })
+
+    it('does reload when it should', async () => {
+        try {
+            await onError({
+                config: {
+                    reloadExpiredSession: true,
+                },
+                response: {
+                    status: 401,
+                    data: {
+                        message: 'Current user is not logged in',
+                    },
+                    headers: {},
+                },
+                request: {
+                    responseURL: '/some/url',
+                },
+            })
+        } catch (e) {
+            expect(e.response.status).toBe(401)
+            expect(window.location.reload).toHaveBeenCalled()
+            return
+        }
+
+        fail('Should not be reached because the original error shall bubble up')
+    })
+})


### PR DESCRIPTION
This is refined version of https://github.com/nextcloud/nextcloud-axios/pull/381 so that
1) the reload is opt-in and not the default
2) reloads only happen for Nextcloud 401s and no others