### PR TITLE
Mark @nextcloud/router as rollup external

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 import typescript from '@rollup/plugin-typescript'
 
-const external = ['axios', '@nextcloud/auth']
+const external = ['axios', '@nextcloud/auth', '@nextcloud/router']
 
 export default [
   {


### PR DESCRIPTION
Makes the build output happy. The generated bundles seem identical from what I could inspect.