### PR TITLE
Fix request cancellation

### DIFF
--- a/lib/interceptors/csrf-token.ts
+++ b/lib/interceptors/csrf-token.ts
@@ -3,8 +3,9 @@ import { generateUrl } from '@nextcloud/router'
 const RETRY_KEY = Symbol('csrf-retry')
 
 export const onError = axios => async (error) => {
-	const { config, response, request: { responseURL } } = error
-	const { status } = response
+	const { config, response, request } = error
+	const responseURL = request?.responseURL
+	const status = response?.status
 
 	if (status === 412
 		&& response?.data?.message === 'CSRF check failed'

--- a/lib/interceptors/maintenance-mode.ts
+++ b/lib/interceptors/maintenance-mode.ts
@@ -1,8 +1,10 @@
 const RETRY_DELAY_KEY = Symbol('retryDelay')
 
 export const onError = axios => async (error) => {
-	const { config, response, request: { responseURL } } = error
-	const { status, headers } = response
+	const { config, response, request } = error
+	const responseURL = request?.responseURL
+	const status = response?.status
+	const headers = response?.headers
 
 	/**
 	 * Retry requests if they failed due to maintenance mode

--- a/lib/interceptors/not-logged-in.ts
+++ b/lib/interceptors/not-logged-in.ts
@@ -1,6 +1,7 @@
 export const onError = async (error) => {
-	const { config, response, request: { responseURL } } = error
-	const { status } = response
+	const { config, response, request } = error
+	const responseURL = request?.responseURL
+	const status = response?.status
 
 	if (status === 401
 		&& response?.data?.message === 'Current user is not logged in'


### PR DESCRIPTION
closes #548

Some `error` attrs are not defined when a request is canceled (with `AbortController` or `CancelToken`).