### PR TITLE
chore(deps): Add renovate bot config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,40 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"config:base",
+		":semanticCommits"
+	],
+	"timezone": "Europe/Vienna",
+	"schedule": [
+		"before 5am on wednesday"
+	],
+	"labels": [
+		"dependencies"
+	],
+	"rangeStrategy": "bump",
+	"rebaseWhen": "conflicted",
+	"ignoreUnstable": false,
+	"baseBranches": [
+		"master"
+	],
+	"enabledManagers": [
+		"npm"
+	],
+	"ignoreDeps": [
+		"node",
+		"npm"
+	],
+	"packageRules": [
+		{
+			"matchUpdateTypes": ["minor", "patch"],
+			"matchCurrentVersion": "!/^0/",
+			"automerge": true,
+			"automergeType": "pr",
+			"platformAutomerge": true
+		},
+		{
+			"matchDepTypes": ["devDependencies"],
+			"extends": ["schedule:monthly"]
+		}
+	]
+}


### PR DESCRIPTION
I'm not able to keep up with the many bumps that are opened. There is too much noise. Let's

1) Bump production deps weekly
2) Bump dev deps monthly
3) Use semantic commits (and one day release automation)