### PR TITLE
fix: Set explicitly file extension for dist files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
 	"name": "@nextcloud/axios",
 	"version": "2.3.0",
 	"description": "Axios client for Nextcloud",
-	"main": "dist/index.js",
+	"main": "dist/index.cjs",
 	"types": "dist/index.d.ts",
-	"module": "dist/index.esm.js",
+	"module": "dist/index.es.mjs",
 	"exports": {
-		"import": "./dist/index.esm.js",
-		"require": "./dist/index.js"
+		"import": "./dist/index.es.mjs",
+		"require": "./dist/index.cjs"
 	},
 	"files": [
 		"dist/"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,7 @@ export default [
     ],
     output: [
       {
-        dir: 'dist',
+        file: 'dist/index.cjs',
         format: 'cjs',
         exports: 'default',
         sourcemap: true,
@@ -24,7 +24,7 @@ export default [
     plugins: [typescript()],
     output: [
       {
-        file: 'dist/index.esm.js',
+        file: 'dist/index.es.mjs',
         format: 'esm',
         sourcemap: true,
       },


### PR DESCRIPTION
As there is no type option in the package, node assumes every file is CommonJS and interprets even the ESM export (`exports` section) as CommonJS. To fix this the files are explicitly named (`.mjs` and `.cjs`).

We could later switch to `type: "module"` and get rid of the `mjs` extension.