### PR TITLE
fix(deps): Install @nextcloud/typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
 				"@babel/preset-env": "^7.21.4",
 				"@babel/preset-typescript": "^7.21.4",
 				"@nextcloud/event-bus": "^3.0.2",
+				"@nextcloud/typings": "^1.6.0",
 				"@rollup/plugin-typescript": "^11.1.0",
 				"babel-jest": "^29.5.0",
 				"jest": "^29.5.0",
@@ -2245,6 +2246,19 @@
 				"npm": "^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/@nextcloud/typings": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.6.0.tgz",
+			"integrity": "sha512-5uIsteFy9Z9/ZaNGE8w8SDgJp+FK8/LeRLgfnakC2pU8eNKTPlQfkiYR163oEI5Xu5YzwdIzf6/roIXdNinhrw==",
+			"dev": true,
+			"dependencies": {
+				"@types/jquery": "2.0.60"
+			},
+			"engines": {
+				"node": "^16.0.0",
+				"npm": "^7.0.0 || ^8.0.0"
+			}
+		},
 		"node_modules/@rollup/plugin-typescript": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.0.tgz",
@@ -2405,6 +2419,12 @@
 			"dependencies": {
 				"@types/istanbul-lib-report": "*"
 			}
+		},
+		"node_modules/@types/jquery": {
+			"version": "2.0.60",
+			"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.60.tgz",
+			"integrity": "sha512-izi6OBEVrAwaHiqWITjOPBbVtcKZKAXTocJqPZsAKA2lvmbpFEyPSAxgcqmisbiMYj9EvrooUEPLHQeQqVMWAg==",
+			"dev": true
 		},
 		"node_modules/@types/jsdom": {
 			"version": "20.0.1",
@@ -7285,6 +7305,15 @@
 				"core-js": "^3.6.4"
 			}
 		},
+		"@nextcloud/typings": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.6.0.tgz",
+			"integrity": "sha512-5uIsteFy9Z9/ZaNGE8w8SDgJp+FK8/LeRLgfnakC2pU8eNKTPlQfkiYR163oEI5Xu5YzwdIzf6/roIXdNinhrw==",
+			"dev": true,
+			"requires": {
+				"@types/jquery": "2.0.60"
+			}
+		},
 		"@rollup/plugin-typescript": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.0.tgz",
@@ -7415,6 +7444,12 @@
 			"requires": {
 				"@types/istanbul-lib-report": "*"
 			}
+		},
+		"@types/jquery": {
+			"version": "2.0.60",
+			"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.60.tgz",
+			"integrity": "sha512-izi6OBEVrAwaHiqWITjOPBbVtcKZKAXTocJqPZsAKA2lvmbpFEyPSAxgcqmisbiMYj9EvrooUEPLHQeQqVMWAg==",
+			"dev": true
 		},
 		"@types/jsdom": {
 			"version": "20.0.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"@babel/preset-env": "^7.21.4",
 		"@babel/preset-typescript": "^7.21.4",
 		"@nextcloud/event-bus": "^3.0.2",
+		"@nextcloud/typings": "^1.6.0",
 		"@rollup/plugin-typescript": "^11.1.0",
 		"babel-jest": "^29.5.0",
 		"jest": "^29.5.0",


### PR DESCRIPTION
Allows the type check to run for now.

```
node_modules/@nextcloud/router/dist/index.d.ts:5:23 - error TS2688: Cannot find type definition file for '@nextcloud/typings'.

5 /// <reference types="@nextcloud/typings" />
                        ~~~~~~~~~~~~~~~~~~

node_modules/@nextcloud/router/dist/index.d.ts:8:13 - error TS2503: Cannot find namespace 'Nextcloud'.

8         OC: Nextcloud.v16.OC | Nextcloud.v17.OC | Nextcloud.v18.OC | Nextcloud.v19.OC | Nextcloud.v20.OC;
              ~~~~~~~~~
```

In the future dependencies might come with their own typing requirement.