### PR TITLE
Fix package for Typescript projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "description": "Axios client for Nextcloud",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",
-  "module": "dist/index.es.mjs",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "import": "./dist/index.es.mjs",
-    "require": "./dist/index.cjs"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.es.mjs",
+      "require": "./dist/index.cjs"
+    }
   },
   "files": [
     "dist/"


### PR DESCRIPTION
Fix the package exports for Typescript projects with module resolution of `node16` or `nodenext`.