### PR TITLE
chore: allow wider `engine` version range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,20 @@
     "vitest": "^3.2.4"
   },
   "engines": {
-    "node": "^20.0.0",
-    "npm": "^10.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "^22.0.0",
+      "onFail": "error"
+    },
+    "packageManager": [
+      {
+        "name": "npm",
+        "version": "^10.5.0",
+        "onFail": "error"
+      }
+    ]
   }
 }


### PR DESCRIPTION
This is not a NodeJS package but a browser package, thus we do not care about the package manager - its only a development dependency. So move it to `devEngines`.
As we support apps for all supported Nextcloud versions, we need to support current Node (22) and also the Node version of the stable Nextcloud version (Node 20).
And we should be future proof and support current active Node 24.