### PR TITLE
fix: CSRF Check failed

### DIFF
--- a/lib/interceptors/csrf-token.ts
+++ b/lib/interceptors/csrf-token.ts
@@ -6,6 +6,7 @@
 import type { CancelableAxiosInstance } from '../client.ts'
 import type { InterceptorErrorHandler } from './index.ts'
 
+import { emit } from '@nextcloud/event-bus'
 import { generateUrl } from '@nextcloud/router'
 import { isAxiosError } from 'axios'
 
@@ -35,6 +36,7 @@ export function onCsrfTokenError(axios: CancelableAxiosInstance): InterceptorErr
 			const { data: { token } } = await axios.get(generateUrl('/csrftoken'))
 			console.debug(`New request token ${token} fetched`)
 			axios.defaults.headers.requesttoken = token
+			emit('csrf-token-update', { token })
 
 			return axios({
 				...config,


### PR DESCRIPTION
fix https://github.com/nextcloud/server/issues/57273

some http request like `/remote.php/dav/trashbin/user/trash/` use it own axios instance ([example trasbin](https://github.com/nextcloud/server/blob/master/apps/files_trashbin/src/services/trashbin.ts#L11))
create by [getClient](https://github.com/nextcloud-libraries/nextcloud-files/blob/main/lib/dav/dav.ts#L69) function, that not add onCsrfTokenError interceptor and will not update requesttoken itself
<img width="1484" height="340" alt="图片" src="https://github.com/user-attachments/assets/7695f109-955f-4bcc-a36e-125c965f4916" />
<img width="1303" height="286" alt="图片" src="https://github.com/user-attachments/assets/e61d573b-02d0-484e-b36d-c711bd15e3e6" />


but it [subscribed csrf-token-update](https://github.com/nextcloud-libraries/nextcloud-files/blob/main/lib/dav/dav.ts#L88), after `emit('csrf-token-update', { token })` it's token will update.

with my commit, when the request has onCsrfTokenError interceptor like  `/ocs/v2.php/apps/notifications/api/v2/notifications` updated token and `emit('csrf-token-update', { token })`, all axios instance will update it's token

mybe we also need modify getClient function, add onCsrfTokenError interceptor for it

