### PR TITLE
chore: deprecate `Axios.CancelToken`

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -9,6 +9,9 @@ import { getRequestToken, onRequestTokenUpdate } from '@nextcloud/auth'
 import Axios from 'axios'
 
 export interface CancelableAxiosInstance extends AxiosInstance {
+	/**
+	 * @deprecated - use the AbortController API instead
+	 */
 	CancelToken: CancelTokenStatic
 	isCancel: typeof Axios.isCancel
 }


### PR DESCRIPTION
The cancel token was deprecated by Axios since v0.22. It was based on a withdrawn approach and nowadays you should use the AbortController API (e.g. the `signal` attribute on the Request config).