### PR TITLE
fix: reorder SPDX headers

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,6 +1,6 @@
 /*!
- * SPDX-License-Identifier: GPL-3.0-or-later
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 import type { AxiosInstance, CancelTokenStatic } from 'axios'

--- a/lib/custom-config.ts
+++ b/lib/custom-config.ts
@@ -1,6 +1,6 @@
 /*!
- * SPDX-License-Identifier: GPL-3.0-or-later
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 // public interface for custom configuration of the Axios client

--- a/lib/interceptors/index.ts
+++ b/lib/interceptors/index.ts
@@ -1,6 +1,6 @@
 /*!
- * SPDX-License-Identifier: GPL-3.0-or-later
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 /**

--- a/lib/internal.d.ts
+++ b/lib/internal.d.ts
@@ -1,6 +1,6 @@
 /*!
- * SPDX-License-Identifier: GPL-3.0-or-later
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 /**


### PR DESCRIPTION
- headers in incorrect order caught in .js.map files during reuse lint CI as incorrect expressions
- CI example: https://github.com/nextcloud/logreader/actions/runs/31294417786/job/93431602336?pr=2174
- docs telling (in examples), that license-identifier should come last in the list of headers: https://reuse.readthedocs.io/en/v0.7.0/usage.html?highlight=license%20expressions#lint
- it's likely an upstream lint issue, but this downstream fix is enough atm


## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
